### PR TITLE
Explicitly disable storage blob public access for workspace templates

### DIFF
--- a/quickstart_101-machine-learning_workspace.tf
+++ b/quickstart_101-machine-learning_workspace.tf
@@ -21,6 +21,7 @@ resource "azurerm_storage_account" "default" {
   resource_group_name      = azurerm_resource_group.default.name
   account_tier             = "Standard"
   account_replication_type = "GRS"
+  allow_nested_items_to_be_public = false
 }
 
 resource "azurerm_container_registry" "default" {

--- a/quickstart_202-machine-learning-moderately-secure-existing-VNet_workspace.tf
+++ b/quickstart_202-machine-learning-moderately-secure-existing-VNet_workspace.tf
@@ -26,6 +26,7 @@ resource "azurerm_storage_account" "default" {
   resource_group_name      = azurerm_resource_group.default.name
   account_tier             = "Standard"
   account_replication_type = "GRS"
+  allow_nested_items_to_be_public = false
 
   network_rules {
     default_action = "Deny"

--- a/quickstart_301-machine-learning-hub-spoke-secure_workspace.tf
+++ b/quickstart_301-machine-learning-hub-spoke-secure_workspace.tf
@@ -27,6 +27,7 @@ resource "azurerm_storage_account" "default" {
   resource_group_name      = azurerm_resource_group.default.name
   account_tier             = "Standard"
   account_replication_type = "GRS"
+  allow_nested_items_to_be_public = false
 
   network_rules {
     default_action = "Deny"


### PR DESCRIPTION
Explicitly disable storage blob public access for workspace templates as the default when creating an AML workspace.