### PR TITLE
101-attestation-provider patch

### DIFF
--- a/quickstart_101-attestation-provider_main.tf
+++ b/quickstart_101-attestation-provider_main.tf
@@ -7,9 +7,37 @@ resource "azurerm_resource_group" "rg" {
   name     = random_pet.rg_name.id
 }
 
+locals {
+  create_signing_cert = try(!fileexists(var.cert_path), true)
+}
+
+resource "tls_private_key" "signing_cert" {
+  count = local.create_signing_cert ? 1 : 0
+
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "tls_self_signed_cert" "attestation" {
+  count = local.create_signing_cert ? 1 : 0
+
+  private_key_pem = tls_private_key.signing_cert[0].private_key_pem
+  validity_period_hours = 12
+  allowed_uses = [
+    "cert_signing",
+  ]
+}
+
+resource "random_string" "attestation_suffix" {
+  length  = 8
+  numeric = false
+  special = false
+  upper   = false
+}
+
 resource "azurerm_attestation_provider" "corp_attestation" {
   location                        = azurerm_resource_group.rg.location
-  name                            = var.attestation_provider_name
+  name                            = "${var.attestation_provider_name}${random_string.attestation_suffix.result}"
   resource_group_name             = azurerm_resource_group.rg.name
-  policy_signing_certificate_data = file(var.policy_file)
+  policy_signing_certificate_data = try(tls_self_signed_cert.attestation[0].cert_pem, file(var.cert_path))
 }

--- a/quickstart_101-attestation-provider_providers.tf
+++ b/quickstart_101-attestation-provider_providers.tf
@@ -10,6 +10,10 @@ terraform {
       source  = "hashicorp/random"
       version = "~>3.0"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "4.0.4"
+    }
   }
 }
 

--- a/quickstart_101-attestation-provider_variables.tf
+++ b/quickstart_101-attestation-provider_variables.tf
@@ -1,8 +1,8 @@
 variable "attestation_provider_name" {
-  default = "attestationprovider007"
+  default = "attestation"
 }
 
-variable "policy_file" {
+variable "cert_path" {
   default = "~/.certs/cert.pem"
 }
 


### PR DESCRIPTION
This pr fix 101-attestation-provider example by adding self-signing cert when user-assigned pem file cannot be found.