### PR TITLE
Fix concurrent error in cosmosdb example

### DIFF
--- a/quickstart_101-cosmos-db-aad-rbac_main.tf
+++ b/quickstart_101-cosmos-db-aad-rbac_main.tf
@@ -9,8 +9,16 @@ resource "azurerm_resource_group" "example" {
   location = var.location
 }
 
+resource "random_pet" "db_account_name" {
+  count = var.cosmosdb_account_name == null ? 1 : 0
+}
+
+locals {
+  cosmosdb_account_name = try(random_pet.db_account_name[0].id, var.cosmosdb_account_name)
+}
+
 resource "azurerm_cosmosdb_account" "example" {
-  name                      = var.cosmosdb_account_name
+  name                      = local.cosmosdb_account_name
   location                  = var.cosmosdb_account_location
   resource_group_name       = azurerm_resource_group.example.name
   offer_type                = "Standard"

--- a/quickstart_101-cosmos-db-aad-rbac_main.tf
+++ b/quickstart_101-cosmos-db-aad-rbac_main.tf
@@ -9,12 +9,17 @@ resource "azurerm_resource_group" "example" {
   location = var.location
 }
 
-resource "random_pet" "db_account_name" {
+resource "random_string" "db_account_name" {
   count = var.cosmosdb_account_name == null ? 1 : 0
+
+  length  = 20
+  upper   = false
+  special = false
+  numeric = false
 }
 
 locals {
-  cosmosdb_account_name = try(random_pet.db_account_name[0].id, var.cosmosdb_account_name)
+  cosmosdb_account_name = try(random_string.db_account_name[0].result, var.cosmosdb_account_name)
 }
 
 resource "azurerm_cosmosdb_account" "example" {
@@ -82,7 +87,9 @@ resource "azurerm_cosmosdb_sql_role_definition" "example" {
   resource_group_name = azurerm_resource_group.example.name
   account_name        = azurerm_cosmosdb_account.example.name
   type                = "CustomRole"
-  assignable_scopes   = ["/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${azurerm_resource_group.example.name}/providers/Microsoft.DocumentDB/databaseAccounts/${azurerm_cosmosdb_account.example.name}"]
+  assignable_scopes   = [
+    "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${azurerm_resource_group.example.name}/providers/Microsoft.DocumentDB/databaseAccounts/${azurerm_cosmosdb_account.example.name}"
+  ]
 
   permissions {
     data_actions = ["Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/read"]

--- a/quickstart_101-cosmos-db-aad-rbac_outputs.tf
+++ b/quickstart_101-cosmos-db-aad-rbac_outputs.tf
@@ -5,3 +5,7 @@ output "cosmosdb_account_id" {
 output "cosmosdb_sql_database_id" {
   value = azurerm_cosmosdb_sql_database.example.id
 }
+
+output "cosmosdb_account_name" {
+  value = azurerm_cosmosdb_account.example.name
+}

--- a/quickstart_101-cosmos-db-aad-rbac_variables.tf
+++ b/quickstart_101-cosmos-db-aad-rbac_variables.tf
@@ -12,7 +12,7 @@ variable "location" {
 
 variable "cosmosdb_account_name" {
   type        = string
-  default     = "default-account-name"
+  default     = null
   description = "Cosmos db account name"
 }
 

--- a/quickstart_101-cosmos-db-analyticalstore_main.tf
+++ b/quickstart_101-cosmos-db-analyticalstore_main.tf
@@ -3,12 +3,17 @@ resource "azurerm_resource_group" "example" {
   location = var.location
 }
 
-resource "random_pet" "db_account_name" {
+resource "random_string" "db_account_name" {
   count = var.cosmosdb_account_name == null ? 1 : 0
+
+  length  = 20
+  upper   = false
+  special = false
+  numeric = false
 }
 
 locals {
-  cosmosdb_account_name = try(random_pet.db_account_name[0].id, var.cosmosdb_account_name)
+  cosmosdb_account_name = try(random_string.db_account_name[0].result, var.cosmosdb_account_name)
 }
 
 resource "azurerm_cosmosdb_account" "example" {

--- a/quickstart_101-cosmos-db-analyticalstore_main.tf
+++ b/quickstart_101-cosmos-db-analyticalstore_main.tf
@@ -3,8 +3,16 @@ resource "azurerm_resource_group" "example" {
   location = var.location
 }
 
+resource "random_pet" "db_account_name" {
+  count = var.cosmosdb_account_name == null ? 1 : 0
+}
+
+locals {
+  cosmosdb_account_name = try(random_pet.db_account_name[0].id, var.cosmosdb_account_name)
+}
+
 resource "azurerm_cosmosdb_account" "example" {
-  name                       = var.cosmosdb_account_name
+  name                       = local.cosmosdb_account_name
   location                   = var.cosmosdb_account_location
   resource_group_name        = azurerm_resource_group.example.name
   offer_type                 = "Standard"

--- a/quickstart_101-cosmos-db-analyticalstore_outputs.tf
+++ b/quickstart_101-cosmos-db-analyticalstore_outputs.tf
@@ -5,3 +5,7 @@ output "cosmosdb_account_id" {
 output "cosmosdb_sql_database_id" {
   value = azurerm_cosmosdb_sql_database.example.id
 }
+
+output "cosmosdb_account_name" {
+  value = azurerm_cosmosdb_account.example.name
+}

--- a/quickstart_101-cosmos-db-analyticalstore_variables.tf
+++ b/quickstart_101-cosmos-db-analyticalstore_variables.tf
@@ -12,7 +12,7 @@ variable "location" {
 
 variable "cosmosdb_account_name" {
   type        = string
-  default     = "default-account-name"
+  default     = null
   description = "Cosmos db account name"
 }
 

--- a/quickstart_101-cosmos-db-autoscale_main.tf
+++ b/quickstart_101-cosmos-db-autoscale_main.tf
@@ -3,12 +3,17 @@ resource "azurerm_resource_group" "example" {
   location = var.location
 }
 
-resource "random_pet" "db_account_name" {
+resource "random_string" "db_account_name" {
   count = var.cosmosdb_account_name == null ? 1 : 0
+
+  length  = 20
+  upper   = false
+  special = false
+  numeric = false
 }
 
 locals {
-  cosmosdb_account_name = try(random_pet.db_account_name[0].id, var.cosmosdb_account_name)
+  cosmosdb_account_name = try(random_string.db_account_name[0].result, var.cosmosdb_account_name)
 }
 
 resource "azurerm_cosmosdb_account" "example" {

--- a/quickstart_101-cosmos-db-autoscale_main.tf
+++ b/quickstart_101-cosmos-db-autoscale_main.tf
@@ -3,8 +3,16 @@ resource "azurerm_resource_group" "example" {
   location = var.location
 }
 
+resource "random_pet" "db_account_name" {
+  count = var.cosmosdb_account_name == null ? 1 : 0
+}
+
+locals {
+  cosmosdb_account_name = try(random_pet.db_account_name[0].id, var.cosmosdb_account_name)
+}
+
 resource "azurerm_cosmosdb_account" "example" {
-  name                      = var.cosmosdb_account_name
+  name                      = local.cosmosdb_account_name
   location                  = var.cosmosdb_account_location
   resource_group_name       = azurerm_resource_group.example.name
   offer_type                = "Standard"

--- a/quickstart_101-cosmos-db-autoscale_outputs.tf
+++ b/quickstart_101-cosmos-db-autoscale_outputs.tf
@@ -5,3 +5,7 @@ output "cosmosdb_account_id" {
 output "cosmosdb_sql_database_id" {
   value = azurerm_cosmosdb_sql_database.main.id
 }
+
+output "cosmosdb_account_name" {
+  value = azurerm_cosmosdb_account.example.name
+}

--- a/quickstart_101-cosmos-db-autoscale_variables.tf
+++ b/quickstart_101-cosmos-db-autoscale_variables.tf
@@ -12,7 +12,7 @@ variable "location" {
 
 variable "cosmosdb_account_name" {
   type        = string
-  default     = "default-cosmosdb-user"
+  default     = null
   description = "Cosmos db account name"
 }
 

--- a/quickstart_101-cosmos-db-free-tier_main.tf
+++ b/quickstart_101-cosmos-db-free-tier_main.tf
@@ -4,7 +4,7 @@ resource "azurerm_resource_group" "example" {
 }
 
 resource "azurerm_cosmosdb_account" "example" {
-  name                      = "${random_pet.prefix.id}-cosmosdb-account"
+  name                      = random_pet.prefix.id
   location                  = var.cosmosdb_account_location
   resource_group_name       = azurerm_resource_group.example.name
   offer_type                = "Standard"

--- a/quickstart_101-cosmos-db-free-tier_outputs.tf
+++ b/quickstart_101-cosmos-db-free-tier_outputs.tf
@@ -5,3 +5,7 @@ output "cosmosdb_account_id" {
 output "cosmosdb_sql_database_id" {
   value = azurerm_cosmosdb_sql_database.main.id
 }
+
+output "cosmosdb_account_name" {
+  value = azurerm_cosmosdb_account.example.name
+}

--- a/quickstart_101-cosmos-db-manualscale_outputs.tf
+++ b/quickstart_101-cosmos-db-manualscale_outputs.tf
@@ -5,3 +5,7 @@ output "cosmosdb_account_id" {
 output "cosmosdb_sql_database_id" {
   value = azurerm_cosmosdb_sql_database.main.id
 }
+
+output "cosmosdb_account_name" {
+  value = azurerm_cosmosdb_account.example.name
+}

--- a/quickstart_101-cosmos-db-serverside-functionality_outputs.tf
+++ b/quickstart_101-cosmos-db-serverside-functionality_outputs.tf
@@ -5,3 +5,7 @@ output "cosmosdb_account_id" {
 output "cosmosdb_sql_database_id" {
   value = azurerm_cosmosdb_sql_database.main.id
 }
+
+output "cosmosdb_account_name" {
+  value = azurerm_cosmosdb_account.example.name
+}


### PR DESCRIPTION
According to the [document](https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-manage-database-account#create-an-account), the CosmosDB account name must be unique:

>Enter a name to identify your Azure Cosmos DB account. Because documents.azure.com is appended to the name that you provide to create your URI, use a unique name. The name can contain only lowercase letters, numbers, and the hyphen (-) character. It must be 3-44 characters.

This pr tried to make account name global unique during the test.