### PR TITLE
Fix broken example `201-confidential-vm`

### DIFF
--- a/quickstart_201-confidential-vm_main.tf
+++ b/quickstart_201-confidential-vm_main.tf
@@ -23,7 +23,7 @@ resource "azurerm_key_vault" "example" {
   soft_delete_retention_days  = 7
 }
 
-resource "azurerm_key_vault_access_policy" "service-principal" {
+resource "azurerm_key_vault_access_policy" "current_user" {
   key_vault_id = azurerm_key_vault.example.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = local.current_user_object_id
@@ -34,6 +34,7 @@ resource "azurerm_key_vault_access_policy" "service-principal" {
     "Get",
     "Purge",
     "Update",
+    "GetRotationPolicy",
   ]
 
   secret_permissions = [
@@ -58,7 +59,7 @@ resource "azurerm_key_vault_key" "example" {
     "wrapKey",
   ]
 
-  depends_on = [azurerm_key_vault_access_policy.service-principal]
+  depends_on = [azurerm_key_vault_access_policy.current_user]
 }
 
 resource "azurerm_disk_encryption_set" "example" {


### PR DESCRIPTION
`201-confidential-vm` was broken by this [issue](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_key#example-usage) so we need to add an extra key permission.