### PR TITLE
101-machine-learning - update the settings of random_string

### DIFF
--- a/quickstart_101-machine-learning_compute.tf
+++ b/quickstart_101-machine-learning_compute.tf
@@ -3,6 +3,7 @@ resource "random_string" "ci_prefix" {
   length  = 8
   upper   = false
   special = false
+  numeric = false
 }
 
 # Compute instance


### PR DESCRIPTION
Currently, the settings of random_string would generate a values starts with number but azurerm_machine_learning_compute_instance doesn't allow it. So I updated the settings of random_string for azurerm_machine_learning_compute_instance.

![image](https://github.com/Azure/terraform/assets/19754191/0763a258-c32f-495f-aa8b-91790c79982f)
